### PR TITLE
Incorporate the Elgamal Large Universe Deleg. KEM into the KEM tests

### DIFF
--- a/src/test/java/de/upb/crypto/craco/kem/test/ElgamalLargeDelegKEMParams.java
+++ b/src/test/java/de/upb/crypto/craco/kem/test/ElgamalLargeDelegKEMParams.java
@@ -1,0 +1,49 @@
+package de.upb.crypto.craco.kem.test;
+
+import de.upb.crypto.craco.interfaces.KeyPair;
+import de.upb.crypto.craco.interfaces.policy.Policy;
+import de.upb.crypto.craco.kem.abe.cp.os.ElgamalLargeUniverseDelegationKEM;
+import de.upb.crypto.craco.kem.abe.cp.os.LUDDecryptionKey;
+import de.upb.crypto.craco.kem.abe.cp.os.LUDEncryptionKey;
+import de.upb.crypto.craco.kem.abe.cp.os.LUDSetup;
+import de.upb.crypto.math.factory.BilinearGroup;
+import de.upb.crypto.math.factory.BilinearGroupFactory;
+import de.upb.crypto.math.hash.impl.SHA256HashFunction;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static de.upb.crypto.craco.kem.test.ElgamalLargeUniverseDelegationKEMTest.getFulfilling;
+import static de.upb.crypto.craco.kem.test.ElgamalLargeUniverseDelegationKEMTest.getNonFulfilling;
+import static de.upb.crypto.craco.kem.test.ElgamalLargeUniverseDelegationKEMTest.setupPolicy;
+
+public class ElgamalLargeDelegKEMParams {
+	public static List<KeyEncapsulationMechanismTestParams> getParams() {
+		BilinearGroupFactory fac = new BilinearGroupFactory(80);
+		fac.setDebugMode(true); // enable debug
+		fac.setRequirements(BilinearGroup.Type.TYPE_3);
+		BilinearGroup bilinearGroup = fac.createBilinearGroup();
+
+		LUDSetup schemeFactory;
+		schemeFactory = new LUDSetup();
+		schemeFactory.setup(bilinearGroup, new SHA256HashFunction());
+		ElgamalLargeUniverseDelegationKEM scheme = schemeFactory.getScheme();
+
+		Policy policy = setupPolicy();
+
+		LUDEncryptionKey encKey = scheme.generateEncryptionKey(policy);
+		/*
+		 * generate satifying and non-satisfying decryption keys for policy
+		 */
+		LUDDecryptionKey dkSatisfy = scheme.generateDecryptionKey(schemeFactory.getMasterSecretKey(), getFulfilling());
+		LUDDecryptionKey dkNonSatisfy = scheme.generateDecryptionKey(schemeFactory.getMasterSecretKey(), getNonFulfilling());
+
+		KeyPair validKeyPair = new KeyPair(encKey, dkSatisfy);
+		KeyPair invalidKeyPair = new KeyPair(encKey, dkNonSatisfy);
+
+		return Stream.of(
+				new KeyEncapsulationMechanismTestParams(scheme, validKeyPair, invalidKeyPair)
+		).collect(Collectors.toList());
+	}
+}

--- a/src/test/java/de/upb/crypto/craco/kem/test/ElgamalLargeUniverseDelegationKEMTest.java
+++ b/src/test/java/de/upb/crypto/craco/kem/test/ElgamalLargeUniverseDelegationKEMTest.java
@@ -123,7 +123,7 @@ public class ElgamalLargeUniverseDelegationKEMTest {
         checkConvertStandalone(scheme);
     }
 
-    private Policy setupPolicy() {
+    static Policy setupPolicy() {
         StringAttribute A = new StringAttribute("A");
         StringAttribute B = new StringAttribute("B");
         StringAttribute C = new StringAttribute("C");
@@ -170,12 +170,12 @@ public class ElgamalLargeUniverseDelegationKEMTest {
 
     }
 
-    private SetOfAttributes getFulfilling() {
+    static SetOfAttributes getFulfilling() {
         //return new SetOfAttributes(new StringAttribute("A"));
         return new SetOfAttributes(new StringAttribute("B"), new StringAttribute("C"), new StringAttribute("hello"));
     }
 
-    private SetOfAttributes getNonFulfilling() {
+    static SetOfAttributes getNonFulfilling() {
         return new SetOfAttributes(new StringAttribute("C"), new StringAttribute("hello"));
     }
 

--- a/src/test/java/de/upb/crypto/craco/kem/test/KeyEncapsulationMechanismTest.java
+++ b/src/test/java/de/upb/crypto/craco/kem/test/KeyEncapsulationMechanismTest.java
@@ -5,6 +5,7 @@ import de.upb.crypto.craco.interfaces.EncryptionKey;
 import de.upb.crypto.craco.interfaces.KeyPair;
 import de.upb.crypto.craco.interfaces.UnqualifiedKeyException;
 import de.upb.crypto.craco.kem.KeyEncapsulationMechanism;
+import de.upb.crypto.craco.kem.abe.cp.os.ElgamalLargeUniverseDelegationKEM;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,6 +43,7 @@ public class KeyEncapsulationMechanismTest {
         schemes.addAll(ABECPWat11KEMParams.getParams());
         schemes.addAll(IBEFuzzySW05KEMParams.getParams());
         schemes.addAll(ABEKPGPSW06KEMParams.getParams());
+        schemes.addAll(ElgamalLargeDelegKEMParams.getParams());
         return schemes;
     }
 


### PR DESCRIPTION
The old Elgamal test is still active, since it tests for more things than we do in the general KEM test.