### PR TITLE
Composite build script update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/**
 build/**
 .idea/**
 .composite-enable
+gradle.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ before_script:
 jobs:
   include:
   - stage: test
-    script: "./gradlew test"
+    script: "./gradlew test -PcheckoutIfCloned=true"
   - stage: build
-    script: "./gradlew build -x test"
+    script: "./gradlew build -x test -PcheckoutIfCloned=true"
   - stage: snapshot
     script: "./gradlew publish -x test -Dnexus.user=$NEXUS_USER -Dnexus.key=$NEXUS_KEY
-      -Dbuild.number=$TRAVIS_BUILD_NUMBER"
+      -Dbuild.number=$TRAVIS_BUILD_NUMBER -PcheckoutIfCloned=true"
   - stage: release
     script: "./gradlew publish -x test -Ddisablesnapshot=true -Dnexus.user=$NEXUS_USER -Dnexus.key=$NEXUS_KEY
       -Dbuild.number=$TRAVIS_BUILD_NUMBER"

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,7 +37,7 @@ if (!Boolean.valueOf(System.getProperty("disablesnapshot"))) {
                             + "Please check it out yourself before building.")
                 }
             } else {
-                println(msgPrefix + libPrefix + ": Branch " + branchThis.getName() + " does not exist locally.")
+                println(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' does not exist locally.")
                 if (grgitLib.branch.list { mode = "REMOTE" }.collect { it.getName() }.contains("origin/" + branchThis.getName())) {
                     if (hasProperty("checkoutIfCloned") && cloned) {
                         println(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' exists but is not checked out. "

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,45 +5,75 @@ import org.ajoberstar.grgit.Grgit
 
 rootProject.name = 'craco'
 
+def msgPrefix = rootProject.name + " settings: "
+
 // do specific snapshot dependency resolution for snapshot builds
 if (!Boolean.valueOf(System.getProperty("disablesnapshot"))) {
     def compositeLibraries = ["upb.crypto.math"]
     for (String lib : compositeLibraries) {
+        def libPrefix = "dependency " + lib
         def libPath = file("../" + lib).getPath()
         def grgitLib
+        def cloned
         if (file(libPath).exists()) {
-            println(lib + ": Local repository exists.")
+            println(msgPrefix + libPrefix + ": Local repository exists.")
             grgitLib = Grgit.open(dir: libPath)
+            cloned = false
         } else {
-            println(lib + ": Local repository does not exist. Cloning to " + libPath + ".")
+            println(msgPrefix + libPrefix + ": Local repository does not exist. Cloning to " + libPath + ".")
             grgitLib = Grgit.clone(dir: libPath, uri: "https://github.com/upbcuk/" + lib + ".git")
+            cloned = true
         }
         def grgitThis = Grgit.open(dir: rootProject.projectDir)
         def branchThis = grgitThis.branch.current()
-        if (file(libPath + "/.git/refs/heads/" + branchThis.getName()).exists()) {
-            if (grgitLib.branch.current().getName() == branchThis.getName()) {
-                println(lib + ": Branch " + branchThis.getName() + " exists and is checked out already.")
-            } else {
-                throw new GradleException(lib + ": Branch " + branchThis.getName() + " exists but is not checked out. "
-                        + "Please check it out yourself before building.")
-            }
+        if (hasProperty("useCurrentBranch")) {
+            println(msgPrefix + libPrefix + ": Parameter 'useCurrentBranch' is set. Using branch '" + grgitLib.branch.current().getName() + "'.")
         } else {
-            println(lib + ": Branch " + branchThis.getName() + " does not exist locally.")
-            if (grgitLib.branch.list { mode = "REMOTE" }.collect { it.getName() }.contains("origin/" + branchThis.getName())) {
-                println(lib + ": Branch " + branchThis.getName() + " exists remotely but not locally. " +
-                        "Please check it out yourself before building.")
-            } else {
-                println(lib + ": Branch " + branchThis.getName() + " does not exist remotely. Using master.")
-                if (grgitLib.branch.current().getName() == "master") {
-                    println(lib + ": Branch master is checked out already. Using it.")
+            if (file(libPath + "/.git/refs/heads/" + branchThis.getName()).exists()) {
+                if (grgitLib.branch.current().getName() == branchThis.getName()) {
+                    println(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' exists and is checked out already.")
                 } else {
-                    throw new GradleException(lib + ": Branch master exists but is not checked out. "
+                    throw new GradleException(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' exists but is not checked out. "
                             + "Please check it out yourself before building.")
+                }
+            } else {
+                println(msgPrefix + libPrefix + ": Branch " + branchThis.getName() + " does not exist locally.")
+                if (grgitLib.branch.list { mode = "REMOTE" }.collect { it.getName() }.contains("origin/" + branchThis.getName())) {
+                    if (hasProperty("checkoutIfCloned") && cloned) {
+                        println(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' exists but is not checked out. "
+                                + "'checkoutIfCloned' is set. Automatically checking it out.")
+                        grgitLib.checkout {
+                            branch = branchThis.getName()
+                            startPoint = "origin/" + branchThis.getName()
+                            createBranch = true
+                        }
+                    } else {
+                        throw new GradleException(msgPrefix + libPrefix + ": Branch '" + branchThis.getName()
+                                + "' exists remotely but not locally. Please check it out yourself before building.")
+                    }
+                } else {
+                    println(msgPrefix + libPrefix + ": Branch '" + branchThis.getName() + "' does not exist remotely. Using master.")
+                    if (grgitLib.branch.current().getName() == "master") {
+                        println(msgPrefix + libPrefix + ": Branch master is checked out already. Using it.")
+                    } else {
+                        if (hasProperty("checkoutIfCloned") && cloned) {
+                            println(msgPrefix + libPrefix + ": Branch master is not checked out. "
+                                    + "'checkoutIfCloned' is set. Automatically checking it out.")
+                            grgitLib.checkout {
+                                branch = branchThis.getName()
+                                startPoint = "origin/" + branchThis.getName()
+                                createBranch = true
+                            }
+                        } else {
+                            throw new GradleException(msgPrefix + libPrefix + ": Branch master exists but is not checked out. "
+                                    + "Please check it out yourself before building.")
+                        }
+                    }
                 }
             }
         }
 
-        println(lib + ": Enabling composite build.")
+        println(msgPrefix + libPrefix + ": Enabling composite build.")
         includeBuild(libPath)
     }
 }


### PR DESCRIPTION
Includes newest addition to the composite build script in settings.gradle, including the `useCurrentBranch` and `checkoutIfCloned` parameters. The former allows you to override the branch name check of any dependencies and just use the currently checked out branch, and the latter allows the script to checkout the right branch on it own if the dependency was cloned by the script (so it won't mess up anything). The latter is necessary for travis to work, as otherwise travis will not be able to check out the correct branch.

Travis stil does not build on this branch, but that is due to math master not including expressions.

These changes are also on the [lazy branch](https://github.com/upbcuk/upb.crypto.craco/tree/lazy), but I don't know when that will be merged, so it seems preferable to get these changes on `master` quickly since `useCurrentBranch` is quite helpful and I would like to have access to it when creating new branches.